### PR TITLE
#5: do not test non-equality of an entity object and a string constant

### DIFF
--- a/PVEntityGenerator/xml/Platform_Java5JPA/entity_entity_unittest-class.xsl
+++ b/PVEntityGenerator/xml/Platform_Java5JPA/entity_entity_unittest-class.xsl
@@ -735,7 +735,6 @@ import org.junit.*;
     </xsl:apply-templates>
     <xsl:text>
     org.junit.Assert.assertFalse(dbo.equals(null));
-    org.junit.Assert.assertFalse(dbo.equals("this is not an entity at all"));
     org.junit.Assert.assertTrue(dbo.equals(dbo));
     org.junit.Assert.assertFalse(dbo.equals(dbo2));
 


### PR DESCRIPTION
This removes a superfluous (IMHO) assertion from `testEquals()`, fixing issue #5. 